### PR TITLE
added correct file name to the native AST output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 py/Pipfile
 go/dhscanner.0.fronts.code-workspace
+tests/
+docker-compose.fronts.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 py/Pipfile
+go/dhscanner.0.fronts.code-workspace

--- a/go/main.go
+++ b/go/main.go
@@ -6,7 +6,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -57,7 +57,7 @@ func toNativeGolangAst(c *gin.Context) {
 	}
 	defer file.Close()
 
-	content, err := ioutil.ReadAll(file)
+	content, err := io.ReadAll(file)
 	if err != nil {
 		c.String(http.StatusInternalServerError, "failed to read file content")
 		return

--- a/go/main.go
+++ b/go/main.go
@@ -1,84 +1,85 @@
 package main
 
 import (
-    "fmt"
-    "io/ioutil"
-    "net/http"
-    "go/parser"
-    "go/token"
-    "go/ast"
-    "bytes"
-    "regexp"
-    "strings"
-    "github.com/gin-gonic/gin"
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 func cleanup_quoted(original string, quote string) string {
-    value := regexp.MustCompile(`(?m)Value: "` + quote + "(.*?)" + quote + `"`)
-    result := value.ReplaceAllStringFunc(original, func(match string) string {
-        start := len("Value: ") + 1
-        end := len(match) - 1
-        withoutValuePrefix := match[start:end]
-        contentNoQuotes := strings.ReplaceAll(withoutValuePrefix, `"`, "")
-        contentNoBackslash := strings.ReplaceAll(contentNoQuotes, "\\", "")
-        contentNoBackticks := strings.ReplaceAll(contentNoBackslash, "`", "")
-        return fmt.Sprintf("Value: \"%s\"", contentNoBackticks)
-    })
-    return result
+	value := regexp.MustCompile(`(?m)Value: "` + quote + "(.*?)" + quote + `"`)
+	result := value.ReplaceAllStringFunc(original, func(match string) string {
+		start := len("Value: ") + 1
+		end := len(match) - 1
+		withoutValuePrefix := match[start:end]
+		contentNoQuotes := strings.ReplaceAll(withoutValuePrefix, `"`, "")
+		contentNoBackslash := strings.ReplaceAll(contentNoQuotes, "\\", "")
+		contentNoBackticks := strings.ReplaceAll(contentNoBackslash, "`", "")
+		return fmt.Sprintf("Value: \"%s\"", contentNoBackticks)
+	})
+	return result
 }
 
 func cleanup_phase_1(original string) string {
-    return cleanup_quoted(original, "`")
+	return cleanup_quoted(original, "`")
 }
 
 func cleanup_phase_0(original string) string {
-    return cleanup_quoted(original, `\\\"`)
+	return cleanup_quoted(original, `\\\"`)
 }
 
 func cleanup(treeRaw string) string {
 
-    tree := cleanup_phase_1(cleanup_phase_0(treeRaw))
-    removeLineNumbers := regexp.MustCompile(`(?m)^\s*\d+  `)
-    treeWithoutLineNumbers := removeLineNumbers.ReplaceAllString(tree, "")
-    removeIndentingDots := regexp.MustCompile(`(?m)^(\.  )*`)
-    return removeIndentingDots.ReplaceAllStringFunc(treeWithoutLineNumbers, func(match string) string {
-        numDots := strings.Count(match, ".  ")
-        return strings.Repeat("    ", numDots)
-    })
+	tree := cleanup_phase_1(cleanup_phase_0(treeRaw))
+	removeLineNumbers := regexp.MustCompile(`(?m)^\s*\d+  `)
+	treeWithoutLineNumbers := removeLineNumbers.ReplaceAllString(tree, "")
+	removeIndentingDots := regexp.MustCompile(`(?m)^(\.  )*`)
+	return removeIndentingDots.ReplaceAllStringFunc(treeWithoutLineNumbers, func(match string) string {
+		numDots := strings.Count(match, ".  ")
+		return strings.Repeat("    ", numDots)
+	})
 }
 
 func toNativeGolangAst(c *gin.Context) {
 
-    file, _, err := c.Request.FormFile("source")
-    if err != nil {
-        c.String(http.StatusBadRequest, "no file was sent")
-        return
-    }
-    defer file.Close()
+	file, header, err := c.Request.FormFile("source")
+	if err != nil {
+		c.String(http.StatusBadRequest, "no file was sent")
+		return
+	}
+	defer file.Close()
 
-    content, err := ioutil.ReadAll(file)
-    if err != nil {
-        c.String(http.StatusInternalServerError, "failed to read file content")
-        return
-    }
+	content, err := ioutil.ReadAll(file)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "failed to read file content")
+		return
+	}
 
-    fset := token.NewFileSet()
-    tree, err := parser.ParseFile(fset, "example.go", content, parser.AllErrors)
-    if err != nil {
-        c.String(http.StatusInternalServerError, "failed to parse golang file")
-        return
-    }
+	fset := token.NewFileSet()
+	tree, err := parser.ParseFile(fset, header.Filename, content, parser.AllErrors)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "failed to parse golang file")
+		return
+	}
 
-    var buf bytes.Buffer
-    ast.Fprint(&buf, fset, tree, nil)
-    result := buf.String()
+	var buf bytes.Buffer
+	ast.Fprint(&buf, fset, tree, nil)
+	result := buf.String()
 
-    c.String(http.StatusOK, cleanup(result))
+	c.String(http.StatusOK, cleanup(result))
 }
 
 func main() {
 
-    r := gin.Default()
-    r.POST("/to/native/go/ast", toNativeGolangAst)
-    r.Run(":8080")
+	r := gin.Default()
+	r.POST("/to/native/go/ast", toNativeGolangAst)
+	r.Run(":8080")
 }


### PR DESCRIPTION
📌 Summary

This PR corrects a filename annotation used in the native Go AST parser endpoint. Previously, the filename was either missing or misleading in debug logs or error traces, which could impact clarity when handling multiple files.

🛠️ Changes Made

Updated the hardcoded filename to a more accurate or descriptive name in the parser.ParseFile call (e.g., "example.go" ➝ "uploaded.go")